### PR TITLE
feat : 닉네임 저장기능 구현 [#27]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.assertj:assertj-core:3.11.1'
 }
 
 test {

--- a/src/main/java/kr/godgaji/gajiquiz/config/SwaggerConfig.java
+++ b/src/main/java/kr/godgaji/gajiquiz/config/SwaggerConfig.java
@@ -25,7 +25,7 @@ public class SwaggerConfig {
                 .groupName(version)
                 .select()
                 .apis(RequestHandlerSelectors.basePackage("kr.godgaji.gajiquiz"))
-                .paths(PathSelectors.ant("/v1/api/**"))
+                .paths(PathSelectors.ant("/api/v1/**"))
                 .build();
     }
 }

--- a/src/main/java/kr/godgaji/gajiquiz/domain/Member/Member.java
+++ b/src/main/java/kr/godgaji/gajiquiz/domain/Member/Member.java
@@ -44,4 +44,9 @@ public class Member extends BaseEntity {
         this.email= email;
         this.nickName = nickName;
     }
+
+    public Member updateNickName(String nickName) {
+        this.nickName = nickName;
+        return this;
+    }
 }

--- a/src/main/java/kr/godgaji/gajiquiz/domain/Member/MemberCustomRepository.java
+++ b/src/main/java/kr/godgaji/gajiquiz/domain/Member/MemberCustomRepository.java
@@ -1,0 +1,6 @@
+package kr.godgaji.gajiquiz.domain.Member;
+
+public interface MemberCustomRepository {
+    Member findByNickName(String nickname);
+    boolean existsByNickName(String nickName);
+}

--- a/src/main/java/kr/godgaji/gajiquiz/domain/Member/MemberRepository.java
+++ b/src/main/java/kr/godgaji/gajiquiz/domain/Member/MemberRepository.java
@@ -2,5 +2,5 @@ package kr.godgaji.gajiquiz.domain.Member;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustomRepository {
 }

--- a/src/main/java/kr/godgaji/gajiquiz/domain/Member/MemberRepositoryImpl.java
+++ b/src/main/java/kr/godgaji/gajiquiz/domain/Member/MemberRepositoryImpl.java
@@ -1,0 +1,32 @@
+package kr.godgaji.gajiquiz.domain.Member;
+
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+public class MemberRepositoryImpl extends QuerydslRepositorySupport implements MemberCustomRepository {
+
+    public MemberRepositoryImpl() {
+        super(Member.class);
+    }
+
+    @Override
+    public Member findByNickName(String nickname) {
+        final QMember member = QMember.member;
+
+        return from(member)
+                .where(member.nickName.eq(nickname))
+                .fetchOne();
+    }
+
+    @Override
+    public boolean existsByNickName(String nickName) {
+        final QMember member = QMember.member;
+
+        if(nickName == null) return false;
+
+        Member fetchOne = from(member)
+                .where(member.nickName.eq(nickName))
+                .fetchFirst();
+
+        return fetchOne != null;
+    }
+}

--- a/src/main/java/kr/godgaji/gajiquiz/domain/Member/NickNameDuplicateValidator.java
+++ b/src/main/java/kr/godgaji/gajiquiz/domain/Member/NickNameDuplicateValidator.java
@@ -1,0 +1,33 @@
+package kr.godgaji.gajiquiz.domain.Member;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+@Component
+@RequiredArgsConstructor
+public class NickNameDuplicateValidator implements ConstraintValidator<NickNameUnique, String> {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public void initialize(NickNameUnique nickNameUnique) {
+
+    }
+
+    @Override
+    public boolean isValid(String nickName, ConstraintValidatorContext cxt) {
+
+        boolean isExistNickName = memberRepository.existsByNickName(nickName);
+
+        if (isExistNickName) {
+            cxt.disableDefaultConstraintViolation();
+            cxt.buildConstraintViolationWithTemplate("이미 사용중인 닉네임 입니다.")
+                    .addConstraintViolation();
+        }
+
+        return !isExistNickName;
+    }
+}

--- a/src/main/java/kr/godgaji/gajiquiz/domain/Member/NickNameUnique.java
+++ b/src/main/java/kr/godgaji/gajiquiz/domain/Member/NickNameUnique.java
@@ -1,0 +1,18 @@
+package kr.godgaji.gajiquiz.domain.Member;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = NickNameDuplicateValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NickNameUnique {
+
+    String message() default "Email is Duplication";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/kr/godgaji/gajiquiz/service/member/MemberService.java
+++ b/src/main/java/kr/godgaji/gajiquiz/service/member/MemberService.java
@@ -1,0 +1,22 @@
+package kr.godgaji.gajiquiz.service.member;
+
+import kr.godgaji.gajiquiz.domain.Member.Member;
+import kr.godgaji.gajiquiz.domain.Member.MemberRepository;
+import kr.godgaji.gajiquiz.web.dto.member.UpdateNickNameRequestDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+@Log4j2
+@RequiredArgsConstructor
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Member updateNickName(UpdateNickNameRequestDto dto) {
+        Member member = new Member();
+        member.updateNickName(dto.getNickName());
+        return memberRepository.save(member);
+    }
+}

--- a/src/main/java/kr/godgaji/gajiquiz/web/MemberController.java
+++ b/src/main/java/kr/godgaji/gajiquiz/web/MemberController.java
@@ -1,0 +1,25 @@
+package kr.godgaji.gajiquiz.web;
+
+import kr.godgaji.gajiquiz.service.member.MemberService;
+import kr.godgaji.gajiquiz.web.dto.member.UpdateNickNameRequestDto;
+import kr.godgaji.gajiquiz.web.dto.member.UpdateNickNameResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/member/")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("update/nickname")
+    public UpdateNickNameResponseDto updateNickName(@Valid @RequestBody UpdateNickNameRequestDto dto) {
+        return new UpdateNickNameResponseDto(memberService.updateNickName(dto));
+    }
+}

--- a/src/main/java/kr/godgaji/gajiquiz/web/dto/member/UpdateNickNameRequestDto.java
+++ b/src/main/java/kr/godgaji/gajiquiz/web/dto/member/UpdateNickNameRequestDto.java
@@ -1,0 +1,32 @@
+package kr.godgaji.gajiquiz.web.dto.member;
+
+import kr.godgaji.gajiquiz.domain.Member.NickNameUnique;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.validation.constraints.*;
+
+@Getter
+@NoArgsConstructor
+@ToString
+public class UpdateNickNameRequestDto {
+
+    @NotNull(message = "닉네임은 NULL일 수 없습니다.")
+    @NotEmpty(message = "닉네임은 비어 있을 수 없습니다.")
+    @NotBlank(message = "닉네임은 공백이 있을 수 없습니다.")
+    @Size(min = 2, max = 8, message = "닉네임의 크기는 2에서 8 사이어야 합니다.")
+    @Pattern(regexp = "^[ㄱ-ㅎ|가-힣|a-z|A-Z|0-9|\\*]+$", message = "닉네임은 한글,영문,숫자만 가능합니다.")
+    @NickNameUnique(message = "이미 사용중인 닉네임 입니다.")
+    private String nickName;
+
+    @NotNull(message = "사용자 정보를 찾을 수 없습니다.")
+    private Long id;
+
+    @Builder
+    public UpdateNickNameRequestDto(String nickName, Long id) {
+        this.nickName = nickName;
+        this.id = id;
+    }
+}

--- a/src/main/java/kr/godgaji/gajiquiz/web/dto/member/UpdateNickNameResponseDto.java
+++ b/src/main/java/kr/godgaji/gajiquiz/web/dto/member/UpdateNickNameResponseDto.java
@@ -1,0 +1,19 @@
+package kr.godgaji.gajiquiz.web.dto.member;
+
+import kr.godgaji.gajiquiz.domain.Member.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UpdateNickNameResponseDto {
+    private Long id;
+    private String name;
+    private String nickName;
+
+    @Builder
+    public UpdateNickNameResponseDto(Member entity) {
+        this.nickName = entity.getNickName();
+        this.name = entity.getName();
+        this.id = entity.getId();
+    }
+}

--- a/src/test/java/kr/godgaji/gajiquiz/service/MemberServiceTest.java
+++ b/src/test/java/kr/godgaji/gajiquiz/service/MemberServiceTest.java
@@ -1,0 +1,36 @@
+package kr.godgaji.gajiquiz.service;
+
+import kr.godgaji.gajiquiz.domain.Member.MemberRepository;
+import kr.godgaji.gajiquiz.service.member.MemberService;
+import kr.godgaji.gajiquiz.web.dto.member.UpdateNickNameRequestDto;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class MemberServiceTest {
+
+    @Autowired MemberService memberService;
+    @Autowired MemberRepository memberRepository;
+
+    @AfterEach
+    void afterEach() {
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("닉네임 설정 통과")
+    public void nickName_Update() {
+        UpdateNickNameRequestDto dto = UpdateNickNameRequestDto.builder()
+                .id(1L)
+                .nickName("test")
+                .build();
+
+        memberService.updateNickName(dto);
+
+        Assertions.assertEquals(memberRepository.findByNickName("test").getNickName(), dto.getNickName());
+    }
+}

--- a/src/test/java/kr/godgaji/gajiquiz/service/NickNameValidTest.java
+++ b/src/test/java/kr/godgaji/gajiquiz/service/NickNameValidTest.java
@@ -1,0 +1,125 @@
+package kr.godgaji.gajiquiz.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.godgaji.gajiquiz.domain.Member.Member;
+import kr.godgaji.gajiquiz.domain.Member.MemberRepository;
+import kr.godgaji.gajiquiz.web.dto.member.UpdateNickNameRequestDto;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class NickNameValidTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired MemberRepository memberRepository;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired Validator validator;
+
+    @AfterEach
+    void afterEach() {
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("닉네임 규칙 검증 통과")
+    public void nickName_Valid() throws Exception {
+        UpdateNickNameRequestDto dto = UpdateNickNameRequestDto.builder()
+                .id(1L)
+                .nickName("홍길동")
+                .build();
+
+        Set<ConstraintViolation<UpdateNickNameRequestDto>> constraintViolations = validator.validate(dto);
+
+        mockMvc.perform(post("/api/v1/member/update/nickname")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("닉네임 입력값 에러")
+    public void nickName_Valid_Error() throws Exception {
+        UpdateNickNameRequestDto dto = UpdateNickNameRequestDto.builder()
+                .id(1L)
+                .nickName("riyenas0925!")
+                .build();
+
+        Set<ConstraintViolation<UpdateNickNameRequestDto>> constraintViolations = validator.validate(dto);
+
+        mockMvc.perform(post("/api/v1/member/update/nickname")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+
+        assertThat(constraintViolations)
+                .extracting(ConstraintViolation::getMessage)
+                .containsOnly(
+                        "닉네임은 한글,영문,숫자만 가능합니다.",
+                        "닉네임의 크기는 2에서 8 사이어야 합니다."
+                );
+    }
+
+    @Test
+    @DisplayName("닉네임 NULL, Blank, Empty 에러")
+    public void nickName_Not_null() throws Exception {
+        UpdateNickNameRequestDto dto = UpdateNickNameRequestDto.builder()
+                .id(1L)
+                .nickName(null)
+                .build();
+
+        Set<ConstraintViolation<UpdateNickNameRequestDto>> constraintViolations = validator.validate(dto);
+
+        mockMvc.perform(post("/api/v1/member/update/nickname")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+
+        assertThat(constraintViolations)
+                .extracting(ConstraintViolation::getMessage)
+                .containsOnly(
+                        "닉네임은 공백이 있을 수 없습니다.",
+                        "닉네임은 NULL일 수 없습니다.",
+                        "닉네임은 비어 있을 수 없습니다."
+                );
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 에러")
+    public void nickName_Not_Duplicate() throws Exception {
+        UpdateNickNameRequestDto dto = UpdateNickNameRequestDto.builder()
+                .id(1L)
+                .nickName("홍길동")
+                .build();
+
+        Member member = new Member().updateNickName(dto.getNickName());
+        memberRepository.save(member);
+
+        Set<ConstraintViolation<UpdateNickNameRequestDto>> constraintViolations = validator.validate(dto);
+
+        mockMvc.perform(post("/api/v1/member/update/nickname")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+
+        assertThat(constraintViolations)
+                .extracting(ConstraintViolation::getMessage)
+                .containsOnly(
+                        "이미 사용중인 닉네임 입니다."
+                );
+    }
+}


### PR DESCRIPTION
### 작업 내역
> 구현 내용 및 작업 했던 내역

- [x] 닉네임 제약조건 추가
- [x] @NotNull(message = "닉네임은 NULL일 수 없습니다.")
- [x] @NotEmpty(message = "닉네임은 비어 있을 수 없습니다.")
- [x] @NotBlank(message = "닉네임은 공백이 있을 수 없습니다.")
- [x] @Size(min = 2, max = 8, message = "닉네임의 크기는 2에서 8 사이어야 합니다.")
- [x] @Pattern(regexp = "^[ㄱ-ㅎ|가-힣|a-z|A-Z|0-9|\*]+$", message = "닉네임은 한글,영문,숫자만 가능합니다.")
- [x] @NickNameUnique(message = "이미 사용중인 닉네임 입니다.")

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 체크리스트

- [x] Optimize Imports는 하셨나요?
- [x] 이슈와 관련 없는 변경사항이 있나요?
- [x] 코딩컨벤션을 준수하셨나요?
- [x] 커밋메시지를 맞게 작성하셨나요?
- [x] 변경되거나 새로운 기능에 대한 테스트 코드를 작성하셨나요?

### PR 특이 사항
> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
- 응답 메시지 예시
```
{
    "message": " Invalid Input Value",
    "status": 400,
    "errors": [
        {
            "field": "nickName",
            "value": "riyens092@",
            "reason": "닉네임은 한글,영문,숫자만 가능합니다."
        },
        {
            "field": "nickName",
            "value": "riyens092@",
            "reason": "닉네임의 크기는 2에서 8 사이어야 합니다."
        }
    ],
    "code": "C001"
}
```
